### PR TITLE
Support modules other than .js

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ mymod = require('./mymodule.js'); // fresh start
 console.log(mymod.count()); // 0   (back to initial state ... zero)
 ```
 
+Modules other than `.js`, like for example, `.jsx`, are supported as well.
+
 If you have any questions or need more examples, please create a GitHub issue:
 https://github.com/nelsonic/decache/issues
 

--- a/decache.js
+++ b/decache.js
@@ -25,11 +25,12 @@ require.find = function (moduleName) {
     // console.log('AFTER: '+moduleName);
 
     var mod;
-    if(moduleName.indexOf('.js') === -1) {
-      mod = moduleName + '\.js'; // append .js to file type
+    var ext = path.extname(moduleName);
+    if(ext === '') {
+      mod = moduleName + '\.js'; // append .js to file type by default
     }
     else {
-      mod = moduleName.replace('.js', '\.js'); // escape .js for regex
+      mod = moduleName.replace(ext, '\\' + ext); // escape extension for regex
     }
 
     var re = new RegExp(mod,"g"); // regex to use when finding the file

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decache",
-  "version": "3.0.5",
+  "version": "3.1.0",
   "description": "decache (Delete Cache) lets you delete modules from node.js require() cache; useful when testing your modules/projects.",
   "main": "decache.js",
   "scripts": {


### PR DESCRIPTION
In the current version, attempting to decache a module like `jsx` will fail, because `decache` will look for a module such as `foo.jsx.js`. This pull requests makes sure that `.js` is added only when there is no extension on the module. Need to add tests for this to prevent future regressions, but for now it fixed my own problem and passes current tests.