### PR TITLE
Fix "Maximum call stack size exceeded" in Node 8+

### DIFF
--- a/decache.js
+++ b/decache.js
@@ -54,14 +54,20 @@ require.searchCache = function (moduleName, callback) {
 
     // Check if the module has been resolved and found within
     // the cache no else so #ignore else http://git.io/vtgMI
-    /* istanbul ignore else  */
+    /* istanbul ignore else */
     if (mod && ((mod = require.cache[mod]) !== undefined)) {
         // Recursively go over the results
         (function run(mod) {
             // Go over each of the module's children and
             // run over it
             mod.children.forEach(function (child) {
-                run(child);
+                // Prevent infinite recursion
+                /* istanbul ignore next */
+                if (child.parent === mod) {
+                  return;
+                } else {
+                  run(child);
+                }
             });
 
             // Call the specified callback providing the


### PR DESCRIPTION
I have tested for #31 in Node 8.7.0 and in projects with more than a few dependencies the behaviour is present. We cannot replicate this by running this module's tests because we do not have enough dependencies to reach the maximum call stack size.