### PR TITLE
ignore .node extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ console.log(mymod.count()); // 0   (back to initial state ... zero)
 
 Modules other than `.js`, like for example, `.jsx`, are supported as well.
 
+Note that native modules with the `.node` extension are ignored from decaching because
+they behave unexpectedly when decached.
+
 If you have any questions or need more examples, please create a GitHub issue:
 https://github.com/nelsonic/decache/issues
 

--- a/decache.js
+++ b/decache.js
@@ -63,7 +63,9 @@ require.searchCache = function (moduleName, callback) {
             // Go over each of the module's children and
             // run over it
             current.children.forEach(function (child) {
-                if (!visited[child.id]) {
+                // ignore .node files, decachine native modules throws a
+                // "module did not self-register" error on second require
+                if (path.extname(child.filename) !== '.node' && !visited[child.id]) {
                     run(child);
                 }
             });

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "istanbul": "^0.4.4",
-    "node-report": "~2.2.1",
+    "modern-syslog": "~1.1.4",
     "pre-commit": "^1.1.3",
     "tap-spec": "^4.1.1",
     "tape": "^4.6.0"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "istanbul": "^0.4.4",
+    "node-report": "~2.2.1",
     "pre-commit": "^1.1.3",
     "tap-spec": "^4.1.1",
     "tape": "^4.6.0"

--- a/test/test.js
+++ b/test/test.js
@@ -76,8 +76,10 @@ test('Fake relative parent module', function(t) {
 });
 
 test('.node extensions are ignored', function(t) {
-  var nativeMod = require('node-report');
-  decache('node-report');
-  t.doesNotThrow(function() {require('node-report')});
+  require('modern-syslog');
+  decache('modern-syslog');
+  t.doesNotThrow(function() {
+      require('modern-syslog');
+  });
   t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -74,3 +74,10 @@ test('Fake relative parent module', function(t) {
   t.equal(keys.indexOf('othermodule.js'), -1, 'fake parent not in require.cache');
   t.end();
 });
+
+test('.node extensions are ignored', function(t) {
+  var nativeMod = require('node-report');
+  decache('node-report');
+  t.doesNotThrow(function() {require('node-report')});
+  t.end();
+});


### PR DESCRIPTION
fixes #19

Problem: node can't decache native modules properly. Our specific use case, we're using [modern-syslog](https://github.com/strongloop/modern-syslog) in a few of our apps and its a pretty bad dev experience for us if we can't decache our react components the way our server side rendering is setup. 

Proposal: credit to @stixx200, ignore .node extensions when recursively decaching. I added a package called [node-report](https://github.com/nodejs/node-report) for testing because it uses a native module. I'm not tied to this package specifically, I chose it because its maintained by the nodejs org and its pretty small. 