### PR TITLE
Update devDependencies issue #49

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ node_modules
 
 .DS_Store
 package-lock.json
+.nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
-  - 0.10
-  - "4.3"
-  - "5.7"
-  - "8.7"
+  - "12"
+  - "node"
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ npm install decache --save-dev
 
 ```js
 // require the decache module:
-var decache = require('decache');
+const decache = require('decache');
 
 // require a module that you wrote"
-var mymod = require('./mymodule.js');
+let mymod = require('./mymodule.js');
 
 // use your module the way you need to:
 console.log(mymod.count()); // 0   (the initial state for our counter is zero)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decache",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "description": "decache (Delete Cache) lets you delete modules from node.js require() cache; useful when testing your modules/projects.",
   "main": "decache.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,10 @@
     "functions": 100,
     "branches": 100,
     "include": [
-      "decache.js"
+      "decache.js",
+      "setup.js",
+      "lib/mymodule/index.js",
+      "lib/othermodule.js"
     ],
     "exclude": [
       "test/test.js"

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "decache (Delete Cache) lets you delete modules from node.js require() cache; useful when testing your modules/projects.",
   "main": "decache.js",
   "scripts": {
-    "nocov": "./node_modules/tape/bin/tape ./test/test.js",
-    "test": "./node_modules/.bin/istanbul cover ./node_modules/tape/bin/tape ./test/*.js",
-    "coverage": "./node_modules/.bin/istanbul cover ./node_modules/tape/bin/tape ./test/*.js && ./node_modules/.bin/istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100"
+    "coverage": "nyc tape ./test/test.js && nyc check-coverage",
+    "nocov": "tape ./test/test.js",
+    "test": "nyc tape ./test/test.js | tap-nyc"
   },
   "repository": {
     "type": "git",
@@ -30,9 +30,10 @@
     "test": "test"
   },
   "devDependencies": {
-    "istanbul": "^0.4.5",
     "modern-syslog": "^1.2.0",
+    "nyc": "^15.0.1",
     "pre-commit": "^1.2.2",
+    "tap-nyc": "^1.0.3",
     "tap-spec": "^5.0.0",
     "tape": "^5.0.0"
   },
@@ -41,5 +42,25 @@
   ],
   "dependencies": {
     "callsite": "^1.0.0"
+  },
+  "nyc": {
+    "check-coverage": true,
+    "lines": 100,
+    "statements": 100,
+    "functions": 100,
+    "branches": 100,
+    "include": [
+      "decache.js"
+    ],
+    "exclude": [
+      "test/test.js"
+    ],
+    "reporter": [
+      "lcov",
+      "text-summary"
+    ],
+    "cache": false,
+    "all": true,
+    "report-dir": "./coverage"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "modern-syslog": "^1.2.0",
     "pre-commit": "^1.2.2",
     "tap-spec": "^5.0.0",
-    "tape": "^4.9.1"
+    "tape": "^5.0.0"
   },
   "pre-commit": [
     "coverage"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "istanbul": "^0.4.5",
-    "modern-syslog": "~1.1.4",
+    "modern-syslog": "^1.2.0",
     "pre-commit": "^1.2.2",
     "tap-spec": "^5.0.0",
     "tape": "^4.9.1"


### PR DESCRIPTION
This is a maintenance update to avoid having a red badge. Fixes #49 
Had to drop older versions of `node.js` from `.travis.yml` as `NYC` uses `ES2015` see: https://github.com/dwyl/decache/issues/49#issuecomment-626460620

Please review & merge when possible. (No Rush!)
Thanks! ☀️ 